### PR TITLE
Emit error when file drop length === 0

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -847,6 +847,13 @@
       }
       this.emit("drop", e);
       files = e.dataTransfer.files;
+
+      // Patch to catch silently passing fail to upload folders for Windows Firefox and IE
+      if(files.length === 0){
+        this.emit("error", "None", "Cannot upload directories, applications, or packages");
+        return;
+      }
+
       if (files.length) {
         items = e.dataTransfer.items;
         if (items && items.length && (items[0].webkitGetAsEntry != null)) {


### PR DESCRIPTION
## Purpose

Dropzone silently fails when folders are uploaded on Window IE and Firefox
## Changes

Files dropped via  Windows IE and Firefox show length === 0, I couldn't find any other situation where this occurred. Emit an error when this is the state of the world.
## Side effects

None known
## Jira Ticket

https://openscience.atlassian.net/browse/OSF-6911
